### PR TITLE
Port genfonts to python3

### DIFF
--- a/display/Makefile
+++ b/display/Makefile
@@ -103,7 +103,7 @@ src/generated_font_data.inc: $(GENFONT)
 	$(GENFONT) --no-flip --bfseries \
 		-r "'0'" "'9'" \
 		-c "':'" \
-	  --space-width 6 \
+		--space-width 6 \
 		-c 0xfffd \
 		-l "data/glyphs/Cantarell/20px/0x0000003a.glyph" \
 		-- \


### PR DESCRIPTION
This ports the genfonts utility to python3.

In the process I fixed a bug regarding the `--space-width` option – it was not implemented (and broke the build process with the python 3 process).