### PR TITLE
display: GCC 8.3 compatibility

### DIFF
--- a/display/src/comm_i2c.inc.c
+++ b/display/src/comm_i2c.inc.c
@@ -214,6 +214,7 @@ void I2C_IRQHandler()
                     backbuffer_ready = true;
                 }
                 NVIC_SetPendingIRQ(received_irqn);
+                __attribute__((fallthrough));
             }
             case MSG_ADDRESS_HOST:
             {

--- a/display/src/comm_uart.inc.c
+++ b/display/src/comm_uart.inc.c
@@ -141,6 +141,7 @@ void uart_tx_irq()
             uart.state.trns_src = (const volatile uint8_t*)uart.queue.items[uart.queue.active_item].header;
             uart.state.trns_end = uart.state.trns_src + sizeof(struct msg_header_t);
         }
+        __attribute__((fallthrough));
     }
     case TXU_SEND_HEADER:
     {
@@ -298,6 +299,7 @@ void uart_rx_irq()
         // missing break is intentional: receive the first bytes immediately
         // turn the timer on
         TMR_COMM_TIMEOUT_TCR = (1<<0) | (0<<1);
+        __attribute__((fallthrough));
     }
     case RXU_RECEIVE_HEADER:
     {
@@ -376,6 +378,7 @@ void uart_rx_irq()
         uart.state.recv_dest = &uart.state.dest_msg->msg.data[0];
         uart.state.recv_end = uart.state.recv_dest + HDR_GET_PAYLOAD_LENGTH(uart.state.curr_header);
         // we can smoothly continue here if more data is available
+        __attribute__((fallthrough));
     }
     case RXU_RECEIVE_PAYLOAD:
     {
@@ -385,6 +388,7 @@ void uart_rx_irq()
         uart_rx_state = RXU_RECEIVE_CHECKSUM;
         uart.state.recv_dest = (uint8_t*)&uart.state.dest_msg->msg.checksum;
         uart.state.recv_end = uart.state.recv_dest + sizeof(msg_checksum_t);
+        __attribute__((fallthrough));
     }
     case RXU_RECEIVE_CHECKSUM:
     {

--- a/display/src/draw.c
+++ b/display/src/draw.c
@@ -2,7 +2,7 @@
 
 #include "lcd.h"
 
-inline void clamp_x(coord_int_t *x)
+static inline void clamp_x(coord_int_t *x)
 {
     if (*x < 0) {
         *x = 0;
@@ -11,7 +11,7 @@ inline void clamp_x(coord_int_t *x)
     }
 }
 
-inline void clamp_y(coord_int_t *y)
+static inline void clamp_y(coord_int_t *y)
 {
     if (*y < 0) {
         *y = 0;
@@ -20,8 +20,8 @@ inline void clamp_y(coord_int_t *y)
     }
 }
 
-inline void rectangle_clamp(coord_int_t *x0, coord_int_t *y0,
-                            coord_int_t *x1, coord_int_t *y1)
+static inline void rectangle_clamp(coord_int_t *x0, coord_int_t *y0,
+                                   coord_int_t *x1, coord_int_t *y1)
 {
     clamp_x(x0);
     clamp_x(x1);
@@ -29,8 +29,8 @@ inline void rectangle_clamp(coord_int_t *x0, coord_int_t *y0,
     clamp_y(y1);
 }
 
-inline void rectangle_clamp_and_swap(coord_int_t *x0, coord_int_t *y0,
-                                     coord_int_t *x1, coord_int_t *y1)
+static inline void rectangle_clamp_and_swap(coord_int_t *x0, coord_int_t *y0,
+                                            coord_int_t *x1, coord_int_t *y1)
 {
     rectangle_clamp(x0, y0, x1, y1);
 

--- a/display/src/font.c
+++ b/display/src/font.c
@@ -2,8 +2,8 @@
 
 #include <stdlib.h>
 
-inline const struct glyph_t *font_find_glyph(const struct font_t *font,
-                                             const codepoint_t codepoint)
+static inline const struct glyph_t *font_find_glyph(const struct font_t *font,
+                                                    const codepoint_t codepoint)
 {
     uint16_t offset = 0;
 

--- a/display/src/lcd.c
+++ b/display/src/lcd.c
@@ -31,14 +31,14 @@ static uint16_t lcd_brightness_awake_backup VAR_RAM = 0xC000;
 
 /* alphabetical order broken so that inlines appear before their use */
 
-inline void _configure_pwm()
+static inline void _configure_pwm()
 {
     GPIO_GPIO1DIR |= (1<<9);
     GPIO_GPIO1DATA &= ~(1<<9);
     IOCON_PIO1_9 = (0x1<<0);
 }
 
-inline void _disable_pwm()
+static inline void _disable_pwm()
 {
     TMR_TMR16B0TCR = 0; // pwm timer
     TMR_TMR16B1TCR = 0; // fade timer
@@ -46,7 +46,7 @@ inline void _disable_pwm()
     GPIO_GPIO1DATA &= ~(1<<9);
 }
 
-inline void _enable_pwm()
+static inline void _enable_pwm()
 {
     GPIO_GPIO1DATA &= ~(1<<9);
     TMR_TMR16B0TC = 0;
@@ -58,7 +58,7 @@ inline void _enable_pwm()
     TMR_TMR16B1TCR = 1; // fade timer
 }
 
-inline void lcd_wrcmd8(uint8_t cmd)
+void lcd_wrcmd8(uint8_t cmd)
 {
     LCD_MASKED_GPIO(LCD_RS_MASK, 0);
     LCD_MASKED_GPIO(LCD_WR_MASK, 0);
@@ -68,7 +68,7 @@ inline void lcd_wrcmd8(uint8_t cmd)
     LCD_MASKED_GPIO(LCD_RS_MASK, LCD_RS_MASK);
 }
 
-inline void lcd_wrdata8(uint8_t data)
+void lcd_wrdata8(uint8_t data)
 {
     LCD_MASKED_GPIO(LCD_WR_MASK, 0);
     LCD_MASKED_GPIO(LCD_DATA_MASK, data);
@@ -76,33 +76,33 @@ inline void lcd_wrdata8(uint8_t data)
     LCD_MASKED_GPIO(LCD_WR_MASK, LCD_WR_MASK);
 }
 
-inline void lcd_wrdata16(uint16_t data)
+void lcd_wrdata16(uint16_t data)
 {
     lcd_wrdata8((data >> 8) & 0xff);
     lcd_wrdata8(data & 0xff);
 }
 
-inline void lcd_draw(uint16_t colour)
+void lcd_draw(uint16_t colour)
 {
     lcd_wrdata16(colour);
 }
 
-inline void lcd_disable()
+void lcd_disable()
 {
     LCD_MASKED_GPIO(LCD_CS_MASK, LCD_CS_MASK);
 }
 
-inline void lcd_enable()
+void lcd_enable()
 {
     LCD_MASKED_GPIO(LCD_CS_MASK, 0);
 }
 
-inline void lcd_drawstart()
+void lcd_drawstart()
 {
     lcd_wrcmd8(LCD_CMD_WRITE);
 }
 
-inline void lcd_drawstop()
+void lcd_drawstop()
 {
 
 }

--- a/display/src/touch.c
+++ b/display/src/touch.c
@@ -236,7 +236,7 @@ void touch_init()
     HIZUP(YM);
 }
 
-inline void calculate_calibration_xy(
+static inline void calculate_calibration_xy(
     const fp11_4_t lcd1,
     const fp11_4_t lcd2,
     const fp11_4_t touch1,


### PR DESCRIPTION
The code could no longer be built with gcc 8.3. See the commit messages for more details.

(A patch to the microbuilder codebase is required as well to build, this is not included in this PR).